### PR TITLE
fix for Safari

### DIFF
--- a/collectionFS_client.api.js
+++ b/collectionFS_client.api.js
@@ -250,7 +250,7 @@ _.extend(_queueCollectionFS.prototype, {
 
 		if (fileItem.queueChunks.length === fileItem.countChunks) {
       //Last worker make chunks into blob
-			var buffers = fileItem.queueChunks.map( function(chunk) {
+			var buffers = _.map(fileItem.queueChunks, function(chunk) {
 			  return chunk.buffer;
 			});
 			self.queue[fileId].blob = new Blob(buffers,


### PR DESCRIPTION
Safari's Blob constructor requires the input to be an array-of-ArrayBuffer rather than an array-of-Uint8Array.  Using ArrayBuffer seems to work on both Chrome and Safari, so it's the lowest common denominator.  Other folks have observed the same phenomenon: 

http://stackoverflow.com/questions/14347534/blob-constructor-not-working-in-safari-opera
