### PR TITLE
Custom Metadata misleading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,8 +629,7 @@ with a file input:
 Template.myForm.events({
   'change .myFileInput': function(event, template) {
     FS.Utility.eachFile(event, function(file) {
-      var newFile = new FS.File();
-      newFile.attachData(file);
+      var newFile = new FS.File(file);
       newFile.metadata = {foo: "bar"};
       Images.insert(newFile, function (err, fileObj) {
         //If !err, we have inserted new doc with ID fileObj._id, and


### PR DESCRIPTION
Constructor FS.File does not work without file in argument. Throws: Uncaught Error: FS.File.attachData requires a data argument with some data
