### PR TITLE
Updated README.md to reflect that FS.File - Objects can't be stored in t...

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Also, rather than setting the `data` property directly, you should use the `atta
 
 ### Storing FS.File references in your objects
 
+**_NOTE:_**
+_At the moment storing FS.File - References in MongoDB on the server side doesn't work. See eg. (https://github.com/CollectionFS/Meteor-cfs-ejson-file/issues/1) (https://github.com/CollectionFS/Meteor-CollectionFS/issues/356)
+(https://github.com/meteor/meteor/issues/1890)._
+
+_Instead store the _id's of your file objects and then fetch the FS.File-Objects from your CollectionFS - Collection._
+
 Often your files are part of another entity. You can store a reference to the file directly in the entity.
 You need to add `cfs-ejson-file` to your packages with `mrt add cfs-ejson-file`.
 Then you can do for example:


### PR DESCRIPTION
Updated README.md to reflect that FS.File - Objects can't be stored in the Server MongoDB at the moment.

Hi, I would suggest adding this warning to the documentation, because this bit me in my first steps using CollectionDB and cost me quite a few hours and caused some headache.

The thing is, it's not obvious that storing FS.File-Objects in the server side MongoDB can cause problems while _updating_ _if the resulting object becomes bigger because of the update_. That's hard stuff, because at first I wrote a whole form, checking that the insert / creation of objects worked, and after that, when trying to add the "update" functionality to my form, came across seemingly random errors with some form submits while others appeared to work.

Quite confusing and hard to debug, and I wouldn't want anyone to be discouraged from using CollectionFS which is pretty grand otherwise.

So I guess adding a warning would be nice towards anybody new trying to get some foothold.
