### PR TITLE
Adding description on how to find docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ CollectionFS
 ============
 
 Meteor webbased filesystem handling up and downloads.
+
+You can find the documentation for each package in packages/{{package-name}}.


### PR DESCRIPTION
Currently there is no pointer on how to find a readme for a specific package. So until the new documentation is ready I am adding this to the main README file.