### PR TITLE
added urlRelative for accessing relative url on cordova

### DIFF
--- a/packages/access-point/access-point-common.js
+++ b/packages/access-point/access-point-common.js
@@ -168,7 +168,7 @@ FS.File.prototype.urlRelative = function(options) {
     // Construct and return the http method url
     return baseUrl + area + '/' + self.collection.name + '/' + self._id + filename + queryString;
   }
-
+};
 
 /**
  * @method FS.File.prototype.url Construct the file url
@@ -189,5 +189,3 @@ FS.File.prototype.url = function(options) {
   self = this;
   return  rootUrlPathPrefix + self.urlRelative(options);
 };
-
-

--- a/packages/access-point/access-point-common.js
+++ b/packages/access-point/access-point-common.js
@@ -55,7 +55,7 @@ FS.HTTP.setBaseUrl = function setBaseUrl(newBaseUrl) {
  */
 
 /**
- * @method FS.File.prototype.url Construct the file url
+ * @method FS.File.prototype.urlRelative Construct the file url
  * @public
  * @param {Object} [options]
  * @param {String} [options.store] Name of the store to get from. If not defined, the first store defined in `options.stores` for the collection on the client is used.
@@ -67,9 +67,9 @@ FS.HTTP.setBaseUrl = function setBaseUrl(newBaseUrl) {
  * @param {String} [options.storing=null] A URL to return while the file is being stored.
  * @param {String} [options.filename=null] Override the filename that should appear at the end of the URL. By default it is the name of the file in the requested store.
  *
- * Returns the HTTP URL for getting the file or its metadata.
+ * Returns the relative HTTP URL for getting the file or its metadata.
  */
-FS.File.prototype.url = function(options) {
+FS.File.prototype.urlRelative = function(options) {
   var self = this;
   options = options || {};
   options = FS.Utility.extend({
@@ -166,9 +166,28 @@ FS.File.prototype.url = function(options) {
     }
 
     // Construct and return the http method url
-    return rootUrlPathPrefix + baseUrl + area + '/' + self.collection.name + '/' + self._id + filename + queryString;
+    return baseUrl + area + '/' + self.collection.name + '/' + self._id + filename + queryString;
   }
 
+
+/**
+ * @method FS.File.prototype.url Construct the file url
+ * @public
+ * @param {Object} [options]
+ * @param {String} [options.store] Name of the store to get from. If not defined, the first store defined in `options.stores` for the collection on the client is used.
+ * @param {Boolean} [options.auth=null] Add authentication token to the URL query string? By default, a token for the current logged in user is added on the client. Set this to `false` to omit the token. Set this to a string to provide your own token. Set this to a number to specify an expiration time for the token in seconds.
+ * @param {Boolean} [options.download=false] Should headers be set to force a download? Typically this means that clicking the link with this URL will download the file to the user's Downloads folder instead of displaying the file in the browser.
+ * @param {Boolean} [options.brokenIsFine=false] Return the URL even if we know it's currently a broken link because the file hasn't been saved in the requested store yet.
+ * @param {Boolean} [options.metadata=false] Return the URL for the file metadata access point rather than the file itself.
+ * @param {String} [options.uploading=null] A URL to return while the file is being uploaded.
+ * @param {String} [options.storing=null] A URL to return while the file is being stored.
+ * @param {String} [options.filename=null] Override the filename that should appear at the end of the URL. By default it is the name of the file in the requested store.
+ *
+ * Returns the HTTP URL for getting the file or its metadata.
+ */
+FS.File.prototype.url = function(options) {
+  self = this;
+  return  rootUrlPathPrefix + self.urlRelative(options);
 };
 
 


### PR DESCRIPTION
The url function returns the relative url on the web and the absolute url (including host) on cordova devices. Sometimes it makes sense to be able to access the relative url on cordova too.

So I extracted the relative url and call it now from the original url() call.

Everything behaves as before, there is only an additional function urlRelative() now available.

So here is how it behaves:

Web:
url() - /some/page
urlRelative() - /some/page

Cordova:
url() - http://ssss:3000/some/page
urlRelative() - /some/page

Would be great if you could pull this into the core.
Cheers,
Gerwin
