### PR TITLE
Fix insertion of file using a URL that does not have a known MIME type.

### DIFF
--- a/packages/file/fsFile-common.js
+++ b/packages/file/fsFile-common.js
@@ -83,6 +83,10 @@ FS.File.prototype.attachData = function fsFileAttachData(data, options, callback
         if (error) {
           callback(error);
         } else {
+          var type = result.type || options.type;
+          if (! type) {
+            throw new Error('FS.File.attachData got a URL for which it could not determine the MIME type and none was provided using options.type');
+          }
           FS.Utility.extend(self, {original: result});
           setData(result.type);
         }

--- a/packages/file/fsFile-common.js
+++ b/packages/file/fsFile-common.js
@@ -88,7 +88,7 @@ FS.File.prototype.attachData = function fsFileAttachData(data, options, callback
             throw new Error('FS.File.attachData got a URL for which it could not determine the MIME type and none was provided using options.type');
           }
           FS.Utility.extend(self, {original: result});
-          setData(result.type);
+          setData(type);
         }
       });
     }


### PR DESCRIPTION
For an example please see `curl -I https://splashbase.s3.amazonaws.com/unsplash/regular/tumblr_n8gybzbUB61st5lhmo1_1280.jpg`.