### PR TITLE
Added the check on chunks from the comments to the getDoneQuery() function

### DIFF
--- a/packages/worker/fileWorker.js
+++ b/packages/worker/fileWorker.js
@@ -124,7 +124,7 @@ function getReadyQuery(storeName) {
  */
 function getDoneQuery(stores) {
   var selector = {
-    $and: []
+    $and: [{chunks: {$exists: true}}]
   };
 
   // Add conditions for all defined stores


### PR DESCRIPTION
Without it every file in the collection will match, which takes a very long time to start up in case of a lot of files.
