### PR TITLE
Added a name set in the Blob type file

### DIFF
--- a/packages/file/fsFile-common.js
+++ b/packages/file/fsFile-common.js
@@ -58,6 +58,7 @@ FS.File.prototype.attachData = function fsFileAttachData(data, options, callback
   }
   // Blob
   else if (typeof Blob !== "undefined" && data instanceof Blob) {
+    self.name(data.name);
     self.updatedAt(new Date());
     self.size(data.size);
     setData(data.type);


### PR DESCRIPTION
added the missing name set, as this creates a chrome warning and also set's the name of the file to undefined.
Should solve this:
https://github.com/CollectionFS/Meteor-CollectionFS/issues/688
