### PR TITLE
Support downloading files with UTF-8 names.

### DIFF
--- a/packages/access-point/access-point-handlers.js
+++ b/packages/access-point/access-point-handlers.js
@@ -1,6 +1,8 @@
 getHeaders = [];
 getHeadersByCollection = {};
 
+var contentDisposition = Npm.require('content-disposition');
+
 FS.HTTP.Handlers = {};
 
 /**
@@ -170,7 +172,7 @@ FS.HTTP.Handlers.Get = function httpGetHandler(ref) {
   // Add 'Content-Disposition' header if requested a download/attachment URL
   if (typeof ref.download !== "undefined") {
     var filename = ref.filename || copyInfo.name;
-    self.addHeader('Content-Disposition', 'attachment; filename="' + filename + '"');
+    self.addHeader('Content-Disposition', contentDisposition(filename));
   } else {
     self.addHeader('Content-Disposition', 'inline');
   }

--- a/packages/access-point/package.js
+++ b/packages/access-point/package.js
@@ -5,6 +5,10 @@ Package.describe({
   git: 'https://github.com/CollectionFS/Meteor-cfs-access-point.git'
 });
 
+Npm.depends({
+  "content-disposition": "0.5.0"
+});
+
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
 


### PR DESCRIPTION
Currently when downloading files with UTF-8 names, it gives error 503 response with message 'unexpected error'.

This PR could fix this problem.

Related [stackoverflow question](http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http).
