### PR TITLE
adding idGeneration: 'MONGO' support

### DIFF
--- a/packages/access-point/access-point-server.js
+++ b/packages/access-point/access-point-server.js
@@ -102,8 +102,14 @@ var defaultSelectorFunction = function() {
   // Get the collection
   var collection = FS._collections[collectionName];
 
-  // Get the file if possible else return null
-  var file = (id && collection)? collection.findOne({ _id: id }): null;
+  //if Mongo ObjectIds are used, then we need to use that in find statement
+  if(collection.options.idGeneration && collection.options.idGeneration === 'MONGO') {
+    // Get the file if possible else return null
+    var file = (id && collection)? collection.findOne({ _id: new Meteor.Collection.ObjectID(id)}): null;
+  } else {
+    var file = (id && collection)? collection.findOne({ _id: id }): null;
+  }
+
 
   // Return the collection and the file
   return {

--- a/packages/collection/common.js
+++ b/packages/collection/common.js
@@ -106,6 +106,8 @@ FS.Collection = function(name, options) {
       return result;
     }
   };
+  
+  if(self.options.idGeneration) _filesOptions.idGeneration = self.options.idGeneration;
 
   // Create the 'cfs.' ++ ".filerecord" and use fsFile
   var collectionName = 'cfs.' + name + '.filerecord';


### PR DESCRIPTION
I have added support for `idGeneration: 'MONGO'` collection option. It is to fix the issue #895, that I reported earlier.

I have tested it myself, but there are no unit tests written. I would be glad to do that as well, but I couldn't immediately figure out how to do that taking rather complicated package structure into account. Is there any contributors guide available? Or any other pointers on how to provide proper test cases? 

p.s. The same change would need to be done for `connection` option, it should be easy to do, but better should be done as separate pull request as it requires different kind of testing. 
