### PR TITLE
cfs:s3 support custom fileKey() function

### DIFF
--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -69,7 +69,9 @@ var imageStore = new FS.Store.S3("images", {
   secretAccessKey: "account or IAM secret", //required if environment variables are not set
   bucket: "mybucket", //required
   ACL: "myValue", //optional, default is 'private', but you can allow public or secure access routed through your app URL
-  folder: "folder/in/bucket", //optional, which folder (key prefix) in the bucket to use 
+  folder: "folder/in/bucket", //optional, which folder (key prefix) in the bucket to use
+  fileKey: function(fileObj) { return new Date().getTime() + "-" + fileObj.name(); }
+
   // The rest are generic store options supported by all storage adapters
   transformWrite: myTransformWriteFunction, //optional
   transformRead: myTransformReadFunction, //optional

--- a/packages/s3/package.js
+++ b/packages/s3/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'cfs:s3',
-  version: '0.1.3',
+  version: '0.1.4',
   summary: "Amazon Web Services S3 storage adapter for CollectionFS",
   git: "https://github.com/CollectionFS/Meteor-CollectionFS/tree/master/packages/s3"
 });

--- a/packages/s3/s3.server.js
+++ b/packages/s3/s3.server.js
@@ -115,6 +115,22 @@ FS.Store.S3 = function(name, options) {
       // If the store and key is found return the key
       if (info && info.key) return info.key;
 
+      // Support explicit fileKey function in options
+      //   eg: set to save as just this filename
+      //   fileKey: function(fileObj) { return { fileKey: fileObj.name() }; }
+      //   eg: set to save as just the fileObj._id
+      //   fileKey: function(fileObj) { return { fileKey: fileObj._id }; }
+      //   eg: set to save as a path: <_id>/<name>
+      //   fileKey: function(fileObj) { return { fileKey: fileObj._id + '/' + fileObj.name() }; }
+      if (options && options.fileKey && typeof options.fileKey === 'function') {
+        return options.fileKey(fileObj);
+      }
+      // Support for an extension on the fileObj itself
+      if (fileObj && fileObj.fileKey) {
+        if (typeof fileObj.fileKey === 'string') return fileObj.fileKey;
+        if (typeof fileObj.fileKey === 'function') return fileObj.fileKey();
+      }
+
       var filename = fileObj.name();
       var filenameInStore = fileObj.name({store: name});
 


### PR DESCRIPTION
```
// Custom fileKey function
var cfsStoreS3 = new FS.Store.S3('s3', {
  bucket: 'mybucket',
  // folder allows you to prefix keys with a static path
  folder: 'static/path',
  // fileKey function allows you to customize keys AFTER the folder
  fileKey: function (fileObj) {
    var id = String(fileObj._id);
    var path = [];
    path.push(id.substring(0, 1));
    path.push(id.substring(1, 2));
    path.push(id.substring(2, 3));
    path.push(id + '-' + fileObj.name());
    return path.join('/');
  }
});

--> /mybucket/static/path/1/2/3/123456tuvwxyz-myfile.jpg
```
