### PR TITLE
Updated dependencies to reflect Meteor 1.4 updates (gridfs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+* Updated cfs:grid mongodb dependency to 2.2.4 (Meteor 1.4)
+
 CollectionFS - DEPRECATED
 ============
 

--- a/packages/gridfs/package.js
+++ b/packages/gridfs/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'cfs:gridfs',
-  version: '0.0.33',
+  version: '0.0.34',
   summary: 'GridFS storage adapter for CollectionFS',
   git: 'https://github.com/CollectionFS/Meteor-cfs-gridfs.git'
 });

--- a/packages/gridfs/package.js
+++ b/packages/gridfs/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Npm.depends({
   mongodb: '2.2.4',
-  'gridfs-stream': '0.5.3'
+  'gridfs-stream': '1.1.1'
   //'gridfs-locking-stream': '0.0.3'
 });
 

--- a/packages/gridfs/package.js
+++ b/packages/gridfs/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  mongodb: '1.4.35',
+  mongodb: '2.2.4',
   'gridfs-stream': '0.5.3'
   //'gridfs-locking-stream': '0.0.3'
 });


### PR DESCRIPTION
Updated dependencies for cfs:gridfs so that package can be used in Meteor 1.4.

**mongodb: '2.2.4',
gridfs-stream: '1.1.1'**

Corrects the issue: 

```
=> Started proxy.

=> Started MongoDB.

I20160726-19:20:34.048(8)? { [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
W20160726-19:20:34.123(8)? (STDERR) js-bson: Failed to load c++ bson extension, using pure JS version
=> Started your app.

=> App running at: http://localhost:3000/
```
