### PR TITLE
add filename conversion for FS.HTTP.Handlers.Get

### DIFF
--- a/packages/access-point/access-point-handlers.js
+++ b/packages/access-point/access-point-handlers.js
@@ -221,7 +221,7 @@ FS.HTTP.Handlers.Get = function httpGetHandler(ref) {
   readStream.pipe(self.createWriteStream());
 };
 
-// Due to unicode or other encoding character filenames can be susscessfull upload to server,
+// File with unicode or other encodings filename can upload to server susscessfully,
 // but when download, the  HTTP header "Content-Disposition" cannot accept 
 // characters other than ASCII, the filename should be converted to binary or URI encoded.
 // https://github.com/wekan/wekan/issues/784

--- a/packages/access-point/access-point-handlers.js
+++ b/packages/access-point/access-point-handlers.js
@@ -221,6 +221,30 @@ FS.HTTP.Handlers.Get = function httpGetHandler(ref) {
   readStream.pipe(self.createWriteStream());
 };
 
+// Due to unicode or other encoding character filenames can be susscessfull upload to server,
+// but when download, the  HTTP header "Content-Disposition" cannot accept 
+// characters other than ASCII, the filename should be converted to binary or URI encoded.
+// https://github.com/wekan/wekan/issues/784
+const originalHandler = FS.HTTP.Handlers.Get;
+FS.HTTP.Handlers.Get = function (ref) {
+  try {
+     var userAgent = (this.requestHeaders['user-agent']||'').toLowerCase();
+
+        if(userAgent.indexOf('msie') >= 0 || userAgent.indexOf('chrome') >= 0) {
+            ref.filename =  encodeURIComponent(ref.filename);
+        } else if(userAgent.indexOf('firefox') >= 0) {
+            ref.filename = new Buffer(ref.filename).toString('binary');
+        } else {
+            /* safari*/
+            ref.filename = new Buffer(ref.filename).toString('binary');
+        }   
+   } catch (ex){
+        ref.filename = ref.filename;
+   } 
+   return originalHandler.call(this, ref);
+};
+
+
 /**
  * @method FS.HTTP.Handlers.PutInsert
  * @public

--- a/packages/access-point/access-point-handlers.js
+++ b/packages/access-point/access-point-handlers.js
@@ -228,16 +228,15 @@ FS.HTTP.Handlers.Get = function httpGetHandler(ref) {
 const originalHandler = FS.HTTP.Handlers.Get;
 FS.HTTP.Handlers.Get = function (ref) {
   try {
-     var userAgent = (this.requestHeaders['user-agent']||'').toLowerCase();
-
-        if(userAgent.indexOf('msie') >= 0 || userAgent.indexOf('chrome') >= 0) {
-            ref.filename =  encodeURIComponent(ref.filename);
-        } else if(userAgent.indexOf('firefox') >= 0) {
-            ref.filename = new Buffer(ref.filename).toString('binary');
-        } else {
-            /* safari*/
-            ref.filename = new Buffer(ref.filename).toString('binary');
-        }   
+      var userAgent = (this.requestHeaders['user-agent']||'').toLowerCase();
+      if(userAgent.indexOf('msie') >= 0 || userAgent.indexOf('chrome') >= 0) {
+          ref.filename =  encodeURIComponent(ref.filename);
+      } else if(userAgent.indexOf('firefox') >= 0) {
+          ref.filename = new Buffer(ref.filename).toString('binary');
+      } else {
+          /* safari*/
+          ref.filename = new Buffer(ref.filename).toString('binary');
+      }   
    } catch (ex){
         ref.filename = ref.filename;
    } 


### PR DESCRIPTION
ref https://github.com/wekan/wekan/issues/784

When click download from card with unicode(Chinese) filename (upload is OK), the server process crash with following exception :

./wekan/bundle/programs/server/node_modules/fibers/future.js:280
throw(ex);
^
TypeError: The header content contains invalid characters
at ServerResponse.OutgoingMessage.setHeader (http.js:733:13)
at ServerResponse.res.setHeader ( /wekan/bundle/programs/server/npm/node_modules/meteor/webapp/node_modules/connect/lib/patch.js:134:22)
at packages/cfs_http-methods/http.methods.server.api.js:599:1
at Function..each..forEach (packages/underscore/underscore.js:113:1)
at packages/cfs_http-methods/http.methods.server.api.js:595:1


it's seems the HTTP header "Content-Disposition" cannot accept unicode encoding characters, and should be binary or URI encoded.

https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
https://my.oschina.net/jsan/blog/180333