### PR TITLE
Enable changing where the filerecord is stored

### DIFF
--- a/packages/collection/common.js
+++ b/packages/collection/common.js
@@ -109,6 +109,12 @@ FS.Collection = function(name, options) {
   
   if(self.options.idGeneration) _filesOptions.idGeneration = self.options.idGeneration;
 
+  // Enable specifying an alternate driver, to change where the filerecord is stored
+  // Drivers can be created with MongoInternals.RemoteCollectionDriver()
+  if(self.options._driver){
+    _filesOptions._driver = self.options._driver;
+  }
+
   // Create the 'cfs.' ++ ".filerecord" and use fsFile
   var collectionName = 'cfs.' + name + '.filerecord';
   self.files = new Mongo.Collection(collectionName, _filesOptions);


### PR DESCRIPTION
Enable specifying an alternate connection driver for FS.Collections, just like you can with regular Collections.
This allows you to change which database the filerecord is stored on.