### PR TITLE
Fix issues with Mongo >= 3.0

### DIFF
--- a/packages/gridfs/gridfs.server.js
+++ b/packages/gridfs/gridfs.server.js
@@ -164,6 +164,11 @@ FS.Store.GridFS = function(name, options) {
       mongodb.MongoClient.connect(options.mongoUrl, mongoOptions, function (err, db) {
         if (err) { return callback(err); }
         self.db = db;
+        
+        // ensure that indexes are added as otherwise CollectionFS fails for Mongo >= 3.0
+        var collection = new Mongo.Collection(gridfsName);
+        collection.rawCollection.ensureIndex({ "files_id": 1, "n": 1});        
+        
         callback(null);
       });
     }

--- a/packages/gridfs/gridfs.server.js
+++ b/packages/gridfs/gridfs.server.js
@@ -167,7 +167,7 @@ FS.Store.GridFS = function(name, options) {
         
         // ensure that indexes are added as otherwise CollectionFS fails for Mongo >= 3.0
         var collection = new Mongo.Collection(gridfsName);
-        collection.rawCollection.ensureIndex({ "files_id": 1, "n": 1});        
+        collection.rawCollection().ensureIndex({ "files_id": 1, "n": 1});        
         
         callback(null);
       });


### PR DESCRIPTION
GridFS implementation dosen't work with new versions of Mongo. Luckily this is only a missing index as reported by other gridfs implementations.

https://github.com/willhuang85/skipper-gridfs/issues/30